### PR TITLE
docs(AGENTS): switch to commit messages for context, add issue-check step

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,19 +13,18 @@ Users should be able to view, create, update, and delete tasks through a clean w
 - Users authenticate with Google OAuth to connect their Google Tasks account.
 - Keep the stack simple. Prefer fewer dependencies over more.
 - Do not delete or modify this file (`AGENTS.md`) or the GitHub Actions workflow (`.github/workflows/grow.yml`).
-- Do not delete any files in `updates/`.
 
 ## How This Works
 
 This project is built autonomously by Codex, running on a schedule via GitHub Actions.
 Each run, you should:
 
-1. Read the latest file(s) in `updates/` to understand the current state of the project.
-2. Decide what to work on next.
-3. Make your changes — write code, install dependencies, create files, etc.
-4. Test your changes if possible (linting, type checking, build, etc.).
-5. Create a new update file in `updates/` prefixed with a UTC timestamp (e.g. `2026-02-23T12-00-00Z-short-description.md`). Include what you did and what should come next.
-6. Commit your changes directly to `main`. A separate push action will follow your run.
+1. Check for open GitHub issues created by the repo owner (@broothie). If any exist, prioritize addressing them before deciding what to work on independently.
+2. Review recent git commit messages (`git log --oneline -20`) to understand the current state of the project and what has already been done.
+3. Decide what to work on next.
+4. Make your changes — write code, install dependencies, create files, etc.
+5. Test your changes if possible (linting, type checking, build, etc.).
+6. Commit your changes directly to `main` with a detailed commit message. The message should describe what changed, why, and what logical next steps are — this is how future runs will pick up context. A separate push action will follow your run.
 
 ## Getting Help
 
@@ -37,5 +36,5 @@ If you get stuck on something that requires outside help (e.g. missing secrets, 
 - Make incremental progress each run. Don't try to do everything at once.
 - Prefer working, minimal implementations over ambitious incomplete ones.
 - If something is broken, fix it before adding new features.
-- Write clear commit messages describing what changed.
-- **Commit to `main` early and often.** You may be cut off at any time without warning. Commit working changes as you go so progress isn't lost. Write the update file and commit it before doing optional cleanup or polish.
+- Write detailed commit messages describing what changed, why, and what should come next. Future runs rely on commit history for context — treat each message as a progress log.
+- **Commit to `main` early and often.** You may be cut off at any time without warning. Commit working changes as you go so progress isn't lost.


### PR DESCRIPTION
- Remove the `updates/` directory workflow; agents now use `git log`
  to understand project history instead of reading update files.
- Commit messages should be detailed (what changed, why, next steps)
  so each run can pick up context from history alone.
- Add a first step to each run: check for open GitHub issues from
  @broothie and prioritize addressing them before self-directed work.
- Drop the constraint against deleting files in `updates/` since that
  directory is no longer part of the workflow.

https://claude.ai/code/session_01McZg51yi5VDNMZsGPs9UgZ